### PR TITLE
Allow oidc username field to be overridden

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -121,7 +121,11 @@ if(!class_exists('Oidc_Auth')) {
          $this->oidc->authenticate();
          $userInfo = $this->oidc->requestUserInfo();
 
-         $user = $userInfo->user_name;
+         if(defined('OIDC_USERNAME_FIELD') && !empty(OIDC_USERNAME_FIELD)) {
+            $user = $userInfo->{OIDC_USERNAME_FIELD};
+         } else {
+            $user = $userInfo->user_name;
+         }
          if(array_key_exists($user, $yourls_user_passwords)) {
             yourls_set_user($user);
             yourls_redirect('.'); // clears URL parameters


### PR DESCRIPTION
OIDC_USERNAME_FIELD will default to "user_name" like the current code does, but allow it to be overridden with "preferred_username" like authentik prefers.